### PR TITLE
add support for displaying full screen images

### DIFF
--- a/conf/themes/reveal.js/plugin/fullscreen-img/fullscreen-img.css
+++ b/conf/themes/reveal.js/plugin/fullscreen-img/fullscreen-img.css
@@ -1,0 +1,54 @@
+/*********************************************
+ * Fullscreen images
+ *********************************************/
+
+.fullscreen {
+  background-size: cover; 
+  -moz-background-size: cover;
+}
+
+.fullscreen .state-background {
+  width: 100%;
+  height: 100%;
+}
+
+.fullscreen .reveal .slides {
+  margin: 0px;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  left: 0px;
+  right: 0px;
+  top:0px;
+  bottom: 0px;
+}
+
+.fullscreen .reveal .slides > section {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  text-align: left;
+  left: 0px;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  margin:0px;
+  padding:20px;
+  padding-top: 40px;
+}
+
+.fullscreen .reveal .slides > section > section {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0px;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  min-height: 100%;
+  margin: 0px;
+  text-align: left;
+  padding:20px;
+  padding-top: 40px;
+}

--- a/conf/themes/reveal.js/plugin/fullscreen-img/fullscreen-img.js
+++ b/conf/themes/reveal.js/plugin/fullscreen-img/fullscreen-img.js
@@ -1,0 +1,48 @@
+// Look for sections that have a fullscreen-img attribute and set this image as
+// the body background image whenever this section is displayed.
+// TODO insert image with reveal transition
+var BGR;
+
+function fullscreen(event) {
+  var url = event.currentSlide.getAttribute("fullscreen-img");
+  if(url) {
+    if(typeof BGR == "undefined")
+    {
+      // Store background value
+      BGR = document.body.style.background;
+    }
+
+    // Set image from fullscreen-img attribute as body background
+    document.body.style.backgroundImage = "url('" + url + "')";
+    var size = event.currentSlide.getAttribute("fullscreen-size");
+    if(size != "contain") {
+      document.body.style.backgroundSize = "cover";
+    }
+    else {
+      // Put image in 'contain' mode with black background
+      // TODO store background color and use it. This is possible by regexping
+      // the background property and replacing the 2nd value by the image url.
+      // See http://www.w3schools.com/cssref/css3_pr_background.asp
+      document.body.style.backgroundColor = "#000000";
+      document.body.style.backgroundSize  = "contain";
+      document.body.style.backgroundRepeat = "no-repeat";
+      document.body.style.backgroundAttachment = "fixed";
+      document.body.style.backgroundPosition = "center center";
+    }
+  }
+  else { 
+    if(typeof BGR != "undefined") { 
+      document.body.style.backgroundImage = "none";
+      document.body.style.background      = BGR;
+    } 
+  }
+}
+
+Reveal.addEventListener('ready', function(event) {
+  fullscreen(event);
+}, false );
+
+Reveal.addEventListener('slidechanged', function(event) {
+  fullscreen(event);
+}, false );
+

--- a/conf/themes/reveal.js/template.html
+++ b/conf/themes/reveal.js/template.html
@@ -22,6 +22,9 @@
 		<!-- For syntax highlighting -->
 		<link rel="stylesheet" href="../../../conf/themes/reveal.js/lib/css/zenburn.css">
 
+		<!-- For fullscreen images (optional, uncomment this and JS below to enable) -->
+		<!--link rel="stylesheet" href="../../../conf/themes/reveal.js/plugin/fullscreen-img/fullscreen-img.css"-->
+
 		<!-- If the query includes 'print-pdf', include the PDF print sheet -->
 		<script>
 			if( window.location.search.match( /print-pdf/gi ) ) {
@@ -84,6 +87,7 @@
 				transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none
 
 				// Optional libraries used to extend on reveal.js
+				// Note: Don't forget to add preceding commas when enabling!
 				dependencies: [
 					{ src: '../../../conf/themes/reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
 					{ src: '../../../conf/themes/reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
@@ -91,6 +95,7 @@
 					{ src: '../../../conf/themes/reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
 					{ src: '../../../conf/themes/reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
 					{ src: '../../../conf/themes/reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
+					// { src: '../../../conf/themes/reveal.js/plugin/fullscreen-img/fullscreen-img.js', async: true, condition: function() { return !!document.body.classList; } }
 					// { src: '../../../conf/themes/reveal.js/plugin/search/search.js', async: true, condition: function() { return !!document.body.classList; } }
 					// { src: '../../../conf/themes/reveal.js/plugin/remotes/remotes.js', async: true, condition: function() { return !!document.body.classList; } }
 				]


### PR DESCRIPTION
Add support for full screen images via https://github.com/regisb/reveal.js-fullscreen-img
